### PR TITLE
Remove obsolete config keys

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -79,6 +79,4 @@ propel:
 
 
 # Jarves Configuration
-jarves:
-    admin: true
-    router: true
+jarves: ~


### PR DESCRIPTION
 Got this error, after cloning this project and running `composer install` 

```bash
[RuntimeException]
  An error occurred when executing the "'cache:clear --no-warmup'" command:

    [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]
    Unrecognized options "admin, router" under "jarves"

  .
````

Removed deprecated config keys `admin` and `router` in app/config/config.yml

Instead just use the default with `jarves: ~`